### PR TITLE
Task 3: Add type definitions

### DIFF
--- a/mcp-prompt-refiner/README.md
+++ b/mcp-prompt-refiner/README.md
@@ -20,6 +20,7 @@ npm start
 [2025-08-13] - Task breakdown completed
 [2025-08-13] - Project setup and dependencies installed
 [2025-08-13] - MCP server scaffold implemented
+[2025-08-13] - Type definitions added
 <!-- Example entries:
 [2024-01-15] - Basic MCP server setup completed
 [2024-01-15] - Prompt analyzer with rule-based scoring implemented

--- a/mcp-prompt-refiner/src/analyzer.ts
+++ b/mcp-prompt-refiner/src/analyzer.ts
@@ -1,15 +1,17 @@
-import { AnalysisResult } from './types';
+import { AnalyzePromptInput, AnalysisResult } from './types';
 
-export function analyzePrompt(prompt: string): AnalysisResult {
+export function analyzePrompt(input: AnalyzePromptInput): AnalysisResult {
   // Placeholder implementation
   return {
     score: 0,
     strengths: [],
     weaknesses: [],
-    clarity_score: 0,
-    specificity_score: 0,
-    context_score: 0,
-    structure_score: 0,
-    completeness_score: 0
+    scores: {
+      clarity: 0,
+      specificity: 0,
+      context: 0,
+      structure: 0,
+      completeness: 0
+    }
   };
 }

--- a/mcp-prompt-refiner/src/comparator.ts
+++ b/mcp-prompt-refiner/src/comparator.ts
@@ -1,6 +1,6 @@
-import { CompareResult } from './types';
+import { ComparePromptsInput, CompareResult } from './types';
 
-export function comparePrompts(prompt_a: string, prompt_b: string): CompareResult {
+export function comparePrompts(input: ComparePromptsInput): CompareResult {
   // Placeholder comparison
   return {
     winner: 'tie',

--- a/mcp-prompt-refiner/src/index.ts
+++ b/mcp-prompt-refiner/src/index.ts
@@ -2,14 +2,15 @@ import fs from 'fs';
 import path from 'path';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { Config } from './types';
 
-function loadConfig() {
+function loadConfig(): Config {
   try {
     const configPath = path.join(__dirname, '..', 'config.json');
     const data = fs.readFileSync(configPath, 'utf-8');
-    return JSON.parse(data);
+    return JSON.parse(data) as Config;
   } catch {
-    return {};
+    return { scoring_weights: { clarity: 0, specificity: 0, context: 0, structure: 0, completeness: 0 }, server: { port: 0, max_prompt_length: 0, rate_limit: 0 } };
   }
 }
 

--- a/mcp-prompt-refiner/src/refiner.ts
+++ b/mcp-prompt-refiner/src/refiner.ts
@@ -1,9 +1,9 @@
-import { RefineResult } from './types';
+import { RefinePromptInput, RefineResult } from './types';
 
-export function refinePrompt(original_prompt: string): RefineResult {
+export function refinePrompt(input: RefinePromptInput): RefineResult {
   // Placeholder refinement
   return {
-    refined_prompt: original_prompt,
+    refined_prompt: input.original_prompt,
     changes_made: [],
     improvement_score: 0,
     original_score: 0,

--- a/mcp-prompt-refiner/src/types.ts
+++ b/mcp-prompt-refiner/src/types.ts
@@ -1,13 +1,28 @@
+export interface AnalyzePromptInput {
+  prompt: string;
+  task_type?: string;
+}
+
+export interface ScoreBreakdown {
+  clarity: number;
+  specificity: number;
+  context: number;
+  structure: number;
+  completeness: number;
+}
+
 export interface AnalysisResult {
   score: number;
   strengths: string[];
   weaknesses: string[];
-  clarity_score: number;
-  specificity_score: number;
-  context_score: number;
-  structure_score: number;
-  completeness_score: number;
+  scores: ScoreBreakdown;
   suggestions?: string[];
+}
+
+export interface RefinePromptInput {
+  original_prompt: string;
+  focus_areas?: string[];
+  task_type?: string;
 }
 
 export interface RefineResult {
@@ -18,10 +33,36 @@ export interface RefineResult {
   refined_score: number;
 }
 
+export interface ComparePromptsInput {
+  prompt_a: string;
+  prompt_b: string;
+  criteria?: string[];
+}
+
 export interface CompareResult {
-  winner: string;
+  winner: 'prompt_a' | 'prompt_b' | 'tie';
   score_a: number;
   score_b: number;
   comparison_details: Record<string, unknown>;
   recommendation: string;
 }
+
+export interface ScoringWeights {
+  clarity: number;
+  specificity: number;
+  context: number;
+  structure: number;
+  completeness: number;
+}
+
+export interface ServerSettings {
+  port: number;
+  max_prompt_length: number;
+  rate_limit: number;
+}
+
+export interface Config {
+  scoring_weights: ScoringWeights;
+  server: ServerSettings;
+}
+

--- a/mcp-prompt-refiner/tasks/task-003-type-definitions.md
+++ b/mcp-prompt-refiner/tasks/task-003-type-definitions.md
@@ -1,6 +1,6 @@
 # Task 003: Type Definitions
 
-**Status:** pending
+**Status:** completed
 **Estimated Time:** 1 hour
 **Dependencies:** Task 001
 
@@ -8,15 +8,15 @@
 Define TypeScript interfaces for tool inputs, outputs, and configuration.
 
 ## Requirements
-- [ ] Create src/types.ts for shared interfaces
-- [ ] Define input/output types for analyze, refine, compare
-- [ ] Specify scoring breakdown structures
-- [ ] Add configuration types for scoring weights and server settings
-- [ ] Export all types for use across modules
+- [x] Create src/types.ts for shared interfaces
+- [x] Define input/output types for analyze, refine, compare
+- [x] Specify scoring breakdown structures
+- [x] Add configuration types for scoring weights and server settings
+- [x] Export all types for use across modules
 
 ## Acceptance Criteria
-- [ ] Type file compiles without errors
-- [ ] Interfaces cover all tool contracts
+- [x] Type file compiles without errors
+- [x] Interfaces cover all tool contracts
 
 ## Files to Create/Modify
 - `src/types.ts`


### PR DESCRIPTION
## Summary
- define TypeScript interfaces for tool inputs, scoring breakdowns, and configuration
- update analyzer, refiner, and comparator to use typed inputs and score structures
- document progress and mark task 003 as complete

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c5ce5f3408330b198c2224dfec6a3