### PR TITLE
Task 4: Implement analyzer foundation

### DIFF
--- a/mcp-prompt-refiner/README.md
+++ b/mcp-prompt-refiner/README.md
@@ -21,6 +21,8 @@ npm start
 [2025-08-13] - Project setup and dependencies installed
 [2025-08-13] - MCP server scaffold implemented
 [2025-08-13] - Type definitions added
+[2025-08-13] - Analyzer foundation implemented
+[2025-08-13] - Analyzer foundation completed
 <!-- Example entries:
 [2024-01-15] - Basic MCP server setup completed
 [2024-01-15] - Prompt analyzer with rule-based scoring implemented

--- a/mcp-prompt-refiner/src/analyzer.ts
+++ b/mcp-prompt-refiner/src/analyzer.ts
@@ -1,17 +1,37 @@
-import { AnalyzePromptInput, AnalysisResult } from './types';
+import { AnalyzePromptInput, AnalysisResult, ScoreBreakdown } from './types';
+
+const MAX_PROMPT_LENGTH = 10000;
 
 export function analyzePrompt(input: AnalyzePromptInput): AnalysisResult {
-  // Placeholder implementation
+  if (!input || typeof input.prompt !== 'string') {
+    throw new Error('Invalid input: prompt is required');
+  }
+
+  const prompt = input.prompt.trim();
+  if (prompt.length === 0) {
+    throw new Error('Invalid input: prompt is empty');
+  }
+
+  if (prompt.length > MAX_PROMPT_LENGTH) {
+    throw new Error(`Prompt exceeds maximum length of ${MAX_PROMPT_LENGTH}`);
+  }
+
+  const scores: ScoreBreakdown = {
+    clarity: 0,
+    specificity: 0,
+    context: 0,
+    structure: 0,
+    completeness: 0
+  };
+
+  const total = Object.values(scores).reduce((sum, s) => sum + s, 0);
+  const average = total / Object.keys(scores).length;
+
   return {
-    score: 0,
+    score: average,
     strengths: [],
     weaknesses: [],
-    scores: {
-      clarity: 0,
-      specificity: 0,
-      context: 0,
-      structure: 0,
-      completeness: 0
-    }
+    scores,
+    suggestions: []
   };
 }

--- a/mcp-prompt-refiner/tasks/task-004-analyzer-foundation.md
+++ b/mcp-prompt-refiner/tasks/task-004-analyzer-foundation.md
@@ -1,6 +1,6 @@
 # Task 004: Analyzer Foundation
 
-**Status:** pending
+**Status:** completed
 **Estimated Time:** 2 hours
 **Dependencies:** Task 003
 
@@ -8,15 +8,15 @@
 Establish core structure for prompt analysis module.
 
 ## Requirements
-- [ ] Implement analyzePrompt function signature in analyzer.ts
-- [ ] Validate prompt length and required fields
-- [ ] Outline scoring categories without logic
-- [ ] Return response object with placeholder scores
-- [ ] Include basic error handling for invalid input
+- [x] Implement analyzePrompt function signature in analyzer.ts
+- [x] Validate prompt length and required fields
+- [x] Outline scoring categories without logic
+- [x] Return response object with placeholder scores
+- [x] Include basic error handling for invalid input
 
 ## Acceptance Criteria
-- [ ] analyzer.ts compiles and exports function
-- [ ] Function returns expected shape with dummy data
+- [x] analyzer.ts compiles and exports function
+- [x] Function returns expected shape with dummy data
 
 ## Files to Create/Modify
 - `src/analyzer.ts`


### PR DESCRIPTION
## Summary
- add placeholder scoring breakdown and compute average score in `analyzePrompt`
- mark analyzer foundation task as completed and log progress

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c60a282b88330935dee724a2053bf