### PR TITLE
Task 006: Add analyzer tests and examples

### DIFF
--- a/mcp-prompt-refiner/README.md
+++ b/mcp-prompt-refiner/README.md
@@ -24,6 +24,8 @@ npm start
 [2025-08-13] - Analyzer foundation implemented
 [2025-08-13] - Analyzer foundation completed
 [2025-08-13] - Scoring rules implemented
+[2025-08-13] - Analyzer testing started
+[2025-08-13] - Analyzer testing completed
 <!-- Example entries:
 [2024-01-15] - Basic MCP server setup completed
 [2024-01-15] - Prompt analyzer with rule-based scoring implemented
@@ -36,7 +38,7 @@ npm start
 - [x] Tasks created and broken down
 - [x] Project setup and dependencies
 - [x] Basic MCP server structure
-- [ ] Prompt analysis implementation
+- [x] Prompt analysis implementation
 - [ ] Prompt refinement logic
 - [ ] Prompt comparison tool
 - [ ] Integration and testing
@@ -61,6 +63,12 @@ Edit `config.json` to adjust scoring weights and server settings.
 Run in development mode:
 ```bash
 npm run dev
+```
+
+## Testing
+Run unit tests with:
+```bash
+npm test
 ```
 
 ## Notes

--- a/mcp-prompt-refiner/examples/bad-prompt.analysis.json
+++ b/mcp-prompt-refiner/examples/bad-prompt.analysis.json
@@ -1,0 +1,13 @@
+{
+  "score": 1.4,
+  "strengths": [],
+  "weaknesses": [],
+  "scores": {
+    "clarity": 2,
+    "specificity": 1,
+    "context": 1,
+    "structure": 2,
+    "completeness": 1
+  },
+  "suggestions": []
+}

--- a/mcp-prompt-refiner/examples/bad-prompt.txt
+++ b/mcp-prompt-refiner/examples/bad-prompt.txt
@@ -1,0 +1,1 @@
+Do stuff about things.

--- a/mcp-prompt-refiner/examples/good-prompt.analysis.json
+++ b/mcp-prompt-refiner/examples/good-prompt.analysis.json
@@ -1,0 +1,13 @@
+{
+  "score": 5.4,
+  "strengths": [],
+  "weaknesses": [],
+  "scores": {
+    "clarity": 10,
+    "specificity": 6,
+    "context": 1,
+    "structure": 2,
+    "completeness": 6
+  },
+  "suggestions": []
+}

--- a/mcp-prompt-refiner/examples/good-prompt.txt
+++ b/mcp-prompt-refiner/examples/good-prompt.txt
@@ -1,0 +1,1 @@
+Write a list of 3 JSON items with edge cases and include success criteria. Provide input and output.

--- a/mcp-prompt-refiner/package.json
+++ b/mcp-prompt-refiner/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "ts-node src/index.ts"
+    "dev": "ts-node src/index.ts",
+    "test": "ts-node tests/analyzer.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.2"

--- a/mcp-prompt-refiner/tasks/task-006-analyzer-testing.md
+++ b/mcp-prompt-refiner/tasks/task-006-analyzer-testing.md
@@ -1,6 +1,6 @@
 # Task 006: Analyzer Testing
 
-**Status:** pending
+**Status:** completed
 **Estimated Time:** 2 hours
 **Dependencies:** Task 005
 
@@ -8,15 +8,15 @@
 Validate analyzer scoring with unit tests and sample prompts.
 
 ## Requirements
-- [ ] Create tests for each scoring function
-- [ ] Test edge cases like empty and long prompts
-- [ ] Add example prompts in examples/ directory
-- [ ] Document test commands in README
-- [ ] Ensure npm test script executes tests
+- [x] Create tests for each scoring function
+- [x] Test edge cases like empty and long prompts
+- [x] Add example prompts in examples/ directory
+- [x] Document test commands in README
+- [x] Ensure npm test script executes tests
 
 ## Acceptance Criteria
-- [ ] All tests pass successfully
-- [ ] Examples demonstrate scoring outputs
+- [x] All tests pass successfully
+- [x] Examples demonstrate scoring outputs
 
 ## Files to Create/Modify
 - `tests/analyzer.test.ts`

--- a/mcp-prompt-refiner/test-results/analyzer-tests.txt
+++ b/mcp-prompt-refiner/test-results/analyzer-tests.txt
@@ -1,0 +1,6 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> mcp-prompt-refiner@0.1.0 test
+> ts-node tests/analyzer.test.ts
+
+All analyzer tests passed

--- a/mcp-prompt-refiner/tests/analyzer.test.ts
+++ b/mcp-prompt-refiner/tests/analyzer.test.ts
@@ -1,0 +1,56 @@
+import assert from 'assert';
+import { analyzePrompt } from '../src/analyzer';
+
+function testClarity() {
+  const prompt = 'Write a list and include details. Provide results.';
+  const result = analyzePrompt({ prompt });
+  assert.strictEqual(result.scores.clarity, 10);
+}
+
+function testSpecificity() {
+  const prompt = 'Provide 3 items in JSON format with exactly 3 entries, for example include edge cases.';
+  const result = analyzePrompt({ prompt });
+  assert.strictEqual(result.scores.specificity, 10);
+}
+
+function testContext() {
+  const prompt = 'Explain steps for a web app for developers so that they can deploy, for example, assuming Node environment.';
+  const result = analyzePrompt({ prompt });
+  assert.strictEqual(result.scores.context, 10);
+}
+
+function testStructure() {
+  const prompt = '1. First, do this.\n\n2. Next, do that.';
+  const result = analyzePrompt({ prompt });
+  assert.strictEqual(result.scores.structure, 10);
+}
+
+function testCompleteness() {
+  const prompt = 'The program must include success criteria when done. Describe input and output assuming valid data and note it depends on configuration.';
+  const result = analyzePrompt({ prompt });
+  assert.strictEqual(result.scores.completeness, 10);
+}
+
+function testEmptyPrompt() {
+  assert.throws(() => analyzePrompt({ prompt: '   ' }));
+}
+
+function testLongPrompt() {
+  const longPrompt = 'a'.repeat(10001);
+  assert.throws(() => analyzePrompt({ prompt: longPrompt }));
+}
+
+try {
+  testClarity();
+  testSpecificity();
+  testContext();
+  testStructure();
+  testCompleteness();
+  testEmptyPrompt();
+  testLongPrompt();
+  console.log('All analyzer tests passed');
+} catch (err) {
+  console.error('Analyzer tests failed');
+  console.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add unit tests for analyzer scoring and validation
- document test usage and progress log updates
- include example prompts with analysis and save test results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c68e9e1848330a1563eb4b31b789e